### PR TITLE
fix: default-area cannot be parsed when not defined

### DIFF
--- a/src/issue.ts
+++ b/src/issue.ts
@@ -36,7 +36,10 @@ export class Issue {
       this.bodyIssueWords = body.split(/ |\(|\)|\./);
     }
     this.parameters = JSON.parse(core.getInput("parameters", {required: true}));
-    this.defaultArea = JSON.parse(core.getInput("default-area", {required: false}));
+    const defaultAreaInput = core.getInput("default-area", {required: false});
+    if (defaultAreaInput) {
+      this.defaultArea = JSON.parse(defaultAreaInput);
+    }
     this.similarity = +core.getInput("similarity", {required: false});
     this.bodyValue = +core.getInput("body-value", {required: false});
   }


### PR DESCRIPTION
Since `default-area` is not required it cannot always be JSON parsed.

The bug was introduced in #9 and breaks actions in https://github.com/aws/aws-cdk 
with `Error: Unexpected end of JSON input`
https://github.com/aws/aws-cdk/runs/4381521997?check_suite_focus=true


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
