### PR TITLE
feat: triage based on issue type

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ If no keywords are detected in your issue, set these default labels and assignee
 }
 ```
 
+### target
+Select whether to run only on issues, pull requests, or both. Valid values are `issues`, `pull-requests`, and `both`
+
+The default value is **both**
+
 ### area-is-keyword
 Setting this to `true` will consider the title of the area to be a keyword of that area
 

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ inputs:
   github-token:
     description: "Github token"
     required: true
+  target:
+    description: "Choose to function only on issues, PRs, or both"
+    required: false
+    default: "both"
   parameters:
     description: "JSON array of keywords to look for and labels and assignees to be set when there's a keyword match"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -4,13 +4,13 @@ inputs:
   github-token:
     description: "Github token"
     required: true
+  parameters:
+    description: "JSON array of keywords to look for and labels and assignees to be set when there's a keyword match"
+    required: true
   target:
     description: "Choose to function only on issues, PRs, or both"
     required: false
     default: "both"
-  parameters:
-    description: "JSON array of keywords to look for and labels and assignees to be set when there's a keyword match"
-    required: true
   area-is-keyword:
     description: "Automatically count the area string as a keyword for that area"
     required: false

--- a/dist/github.d.ts
+++ b/dist/github.d.ts
@@ -11,4 +11,5 @@ export declare class GithubApi {
     setIssueAssignees(assignees: string[]): Promise<void>;
     setIssueLabels(labels: string[]): Promise<void>;
     getIssueContent(): Promise<IIssueData>;
+    isIssue(): boolean;
 }

--- a/dist/github.d.ts
+++ b/dist/github.d.ts
@@ -11,5 +11,5 @@ export declare class GithubApi {
     setIssueAssignees(assignees: string[]): Promise<void>;
     setIssueLabels(labels: string[]): Promise<void>;
     getIssueContent(): Promise<IIssueData>;
-    isIssue(): boolean;
+    verifyIssueType(data: any): boolean;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -28070,12 +28070,16 @@ class GithubApi {
             for (const label of data.labels) {
                 labels.push(label.name.toString());
             }
+            console.log(data.pull_request);
             return {
                 title,
                 body,
                 labels,
             };
         });
+    }
+    isIssue() {
+        return false;
     }
 }
 exports.GithubApi = GithubApi;

--- a/dist/issue.d.ts
+++ b/dist/issue.d.ts
@@ -2,6 +2,7 @@ export interface IIssueData {
     title?: string;
     body?: string;
     labels?: string[];
+    isValidIssueType?: boolean;
 }
 export interface IParameter extends IDefaultArea {
     area: string;

--- a/src/__tests__/github.test.ts
+++ b/src/__tests__/github.test.ts
@@ -157,12 +157,11 @@ test("getIssueContent() requests GitHub's API, when issueNumber is set", async (
 
 test('VerifyIssueType returns true when target is both', async () => {
   process.env.INPUT_TARGET = 'both';
-
-  const githubApi = new GithubApi('GITHUB_TOKEN');
-
   const data = {
     pull_request: ['pullrequest'],
   };
+
+  const githubApi = new GithubApi('GITHUB_TOKEN');
 
   expect(githubApi.verifyIssueType(data)).toStrictEqual(true);
 });

--- a/src/__tests__/github.test.ts
+++ b/src/__tests__/github.test.ts
@@ -151,5 +151,44 @@ test("getIssueContent() requests GitHub's API, when issueNumber is set", async (
     title: 'test-title',
     body: 'test-body',
     labels: ['needs-triage'],
+    isValidIssueType: true,
   });
+});
+
+test('VerifyIssueType returns true when target is both', async () => {
+  process.env.INPUT_TARGET = 'both';
+
+  const githubApi = new GithubApi('GITHUB_TOKEN');
+
+  const data = {
+    pull_request: ['pullrequest'],
+  };
+
+  expect(githubApi.verifyIssueType(data)).toStrictEqual(true);
+});
+
+test('VerifyIssueType returns correct value when target is issues', async () => {
+  process.env.INPUT_TARGET = 'issues';
+  const prData = {
+    pull_request: ['pullrequest'],
+  };
+  const issueData = undefined;
+
+  const githubApi = new GithubApi('GITHUB_TOKEN');
+
+  expect(githubApi.verifyIssueType(prData)).toStrictEqual(false);
+  expect(githubApi.verifyIssueType(issueData)).toStrictEqual(true);
+});
+
+test('VerifyIssueType returns correct value when target is pull-requests', async () => {
+  process.env.INPUT_TARGET = 'pull-requests';
+  const prData = {
+    pull_request: ['pullrequest'],
+  };
+  const issueData = undefined;
+
+  const githubApi = new GithubApi('GITHUB_TOKEN');
+
+  expect(githubApi.verifyIssueType(prData)).toStrictEqual(true);
+  expect(githubApi.verifyIssueType(issueData)).toStrictEqual(false);
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -57,10 +57,16 @@ export class GithubApi {
       labels.push(label.name.toString());
     }
 
+    console.log(data.pull_request);
+
     return {
       title,
       body,
       labels,
     };
+  }
+
+  public isIssue(): boolean {
+    return false;
   }
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -49,6 +49,10 @@ export class GithubApi {
       issue_number: this.issueNumber,
     });
 
+    const isValidIssueType = this.verifyIssueType(data.pull_request);
+
+    if (!isValidIssueType) return {isValidIssueType: false};
+
     const title: string = data.title;
     const body: string = data.body;
     const labels: string[] = [];
@@ -57,16 +61,33 @@ export class GithubApi {
       labels.push(label.name.toString());
     }
 
-    console.log(data.pull_request);
-
     return {
       title,
       body,
       labels,
+      isValidIssueType,
     };
   }
 
-  public isIssue(): boolean {
-    return false;
+  public verifyIssueType(data): boolean {
+    const target = core.getInput('target', {required: false});
+
+    if (target === 'both') {
+      return true;
+    } else if (target === 'issues') {
+      if (!data) {
+        return true;
+      } else {
+        return false;
+      }
+    } else if (target === 'pull-requests') {
+      if (data) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,14 @@ async function run() {
   const token = core.getInput('github-token');
   const github: GithubApi = new GithubApi(token);
   const content: IIssueData = await github.getIssueContent();
+
+  if (!content.isValidIssueType) {
+    core.info(
+      'This issue is not the correct target type. Exiting successfully'
+    );
+    return;
+  }
+
   const includedLabels: string[] | undefined = core
     .getInput('included-labels', {required: false})
     .replace(/\[|\]/gi, '')

--- a/src/issue.ts
+++ b/src/issue.ts
@@ -6,6 +6,7 @@ export interface IIssueData {
   title?: string;
   body?: string;
   labels?: string[];
+  isValidIssueType?: boolean;
 }
 
 export interface IParameter extends IDefaultArea {


### PR DESCRIPTION
This PR introduces a new optional input variable `target`. By default, things will work the same and the value will be set to `both` to function on both PRs and Issues. Use `issues` to only triage issues, and use `pull-requests` to only triage PRs

This feature will help optimize CDK issue triaging.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
